### PR TITLE
fix some type inconsistencies, add type variant to an Options param

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -197,7 +197,7 @@ declare module 'openseadragon'{
     export interface Options{
         id? : string,
         element ? : HTMLElement,
-        tileSources ?: string | TileSource[],
+        tileSources ?: string | string[] | TileSource[],
         tabIndex ? : number,
         overlays? : any[],
         prefixUrl? : string,
@@ -232,7 +232,7 @@ declare module 'openseadragon'{
         minScrollDeltaTime?: number,
         pixelsPerWheelLine?: number,
         pixelsPerArrowPress?: number,
-        visibilityRatio?: boolean,
+        visibilityRatio?: number,
         viewportMargins?: object,
         imageLoaderLimit?: number,
         clickTimeThreshold?: number,


### PR DESCRIPTION
* Make `visibilityRatio`'s type annotation `number` across all references (#2)
* Add `string[]` variant to `tileSources` param of `Options` interface