### PR TITLE
Correct default export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1459,4 +1459,4 @@ interface WorldEvent extends OSDEvent<World> {
   newIndex?: number;
 }
 
-export default Viewer;
+export default function(options: Options): Viewer;


### PR DESCRIPTION
Allows you to do 

```js
const viewer = OpenSeadragon(options)
``` 

instead of the workaround

```js
const viewer = new OpenSeadragon.Viewer(options)
```

Closes #1.