### PR TITLE
Allow TileSourceOptions for Options.tileSources

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -237,6 +237,7 @@ export interface Options {
       | string
       | string[]
       | TileSource[]
+      | TileSourceOptions
       | {
             Image: {
                 xmlns?: string;


### PR DESCRIPTION
It's hard to verify this in the docs but there's an example that shows this: 

https://openseadragon.github.io/examples/tilesource-custom/

It works for me.