### PR TITLE
Update DziTileSource class constructor

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -555,12 +555,16 @@ export class DziTileSource extends TileSource {
       height: number,
       tileSize: number,
       tileOverlap: number,
-      tilesUrl: number,
-      fileFormat: number,
-      displayRects: number,
-      minLevel: number,
-      maxLevel: number
+      tilesUrl: string,
+      fileFormat: string,
+      displayRects?: DisplayRect[],
+      minLevel?: number,
+      maxLevel?: number
   );
+
+  tilesUrl: string;
+  fileFormat: string;
+  displayRects?: DisplayRect[];
 }
 
 export class IIIFTileSource extends TileSource {}


### PR DESCRIPTION
Fixed DZI tile source constructor. There's a bit of dissonance between [the docs](http://openseadragon.github.io/docs/OpenSeadragon.DziTileSource.html) and the source code so I tried to split the difference with a sensible solution. I've confirmed that my implementation will load the DZI